### PR TITLE
do not allow change of order in the AZs

### DIFF
--- a/helm/opa-mutator-app/rules/functions.rego
+++ b/helm/opa-mutator-app/rules/functions.rego
@@ -109,3 +109,13 @@ n_shifted_values(array_in, n) = array_out {
   shifted := array.concat(array_a, array_b)
   array_out := array.slice(shifted, 0, n)
 }
+
+add_n_values(array_in, elem, n) = array_out {
+  array_in[k] != elem
+  addedValues := n_shifted_values(array_in[k], n)
+  array_out := array.concat(cast_array(elem),addedValues)
+}
+
+orderChanged(array_old, array_new) {
+  array_old[i] == array_new[j]; i!=j
+}

--- a/helm/opa-mutator-app/rules/rules_awscontrolplane.rego
+++ b/helm/opa-mutator-app/rules/rules_awscontrolplane.rego
@@ -115,3 +115,15 @@ patch["default_instance_type"] = mutation {
         {"op": "add", "path": "/spec/instanceType", "value": vars.defaultInstanceType},
     ]
 }
+
+# On update we need to keep the order of AZs
+deny[msg] {
+    functions.is_update
+    input.request.kind.kind = "AWSControlPlane"
+    newAZ = input.request.object.spec.availabilityZones
+    oldAZ = input.request.oldObject.spec.availabilityZones
+    is_array(oldAZ)
+    is_array(newAZ)
+    functions.orderChanged(oldAZ, newAZ)
+    msg = "Can not change the order of availability zones."
+}

--- a/test/awscontrolplane-mocks.rego
+++ b/test/awscontrolplane-mocks.rego
@@ -801,7 +801,9 @@ create_valid_awscontrolplane_update = {
          },
          "spec": {
            "availabilityZones": [
+               "eu-central-1c",
                "eu-central-1b",
+               "eu-central-1a",
             ],
            "instanceType": "m4.xlarge"
          }

--- a/test/awscontrolplane-mocks.rego
+++ b/test/awscontrolplane-mocks.rego
@@ -734,3 +734,82 @@ create_valid_awscontrolplane_preha = {
       }
    }
 }
+
+create_valid_awscontrolplane_update = {
+   "kind":"AdmissionReview",
+   "apiVersion":"admission.k8s.io/v1beta1",
+   "request":{
+      "uid":"d06e33d2-d618-4787-8a68-2b005f063169",
+      "kind":{
+         "group":"",
+         "version":"v1alpha2",
+         "kind":"AWSControlPlane"
+      },
+      "resource":{
+         "group":"",
+         "version":"v1alpha2",
+         "resource":"infrastructure.giantswarm.io"
+      },
+      "requestKind":{
+         "group":"",
+         "version":"v1alpha2",
+         "kind":"AWSControlPlane"
+      },
+      "requestResource":{
+         "group":"",
+         "version":"v1alpha2",
+         "resource":"infrastructure.giantswarm.io"
+      },
+      "name":"hacp1",
+      "namespace":"default",
+      "operation":"UPDATE",
+      "userInfo":{
+         "username":"kubernetes-admin",
+         "groups":[
+            "system:masters",
+            "system:authenticated"
+         ]
+      },
+      "object":{
+         "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+         "kind": "AWSControlPlane",
+         "metadata": {
+           "annotations": {
+             "giantswarm.io/docs": "https://docs.giantswarm.io/reference/cp-k8s-api/"
+           },
+           "creationTimestamp": null,
+           "name": "hacp1"
+         },
+         "spec": {
+           "availabilityZones": [
+               "eu-central-1a",
+               "eu-central-1b",
+               "eu-central-1c",
+            ],
+           "instanceType": "m4.xlarge"
+         }
+      },
+      "oldObject":{
+         "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+         "kind": "AWSControlPlane",
+         "metadata": {
+           "annotations": {
+             "giantswarm.io/docs": "https://docs.giantswarm.io/reference/cp-k8s-api/"
+           },
+           "creationTimestamp": null,
+           "name": "hacp1"
+         },
+         "spec": {
+           "availabilityZones": [
+               "eu-central-1b",
+            ],
+           "instanceType": "m4.xlarge"
+         }
+      },
+      "dryRun":false,
+      "options":{
+         "kind":"CreateOptions",
+         "apiVersion":"meta.k8s.io/v1"
+      }
+   }
+}

--- a/test/awscontrolplane-test.rego
+++ b/test/awscontrolplane-test.rego
@@ -122,3 +122,10 @@ test_create_valid_awscontrolplane_checkg8shafail {
     contains(deny[_], "Number of Availability Zones different than defined in G8SControlPlane")
     count(deny) = 1
 }
+
+# Check if the order of AZs was changed
+test_create_valid_awscontrolplane_update {
+    deny = admission.deny with input as mocks.create_valid_awscontrolplane_update
+    contains(deny[_], "Can not change the order of availability zones.")
+    count(deny) = 1
+}


### PR DESCRIPTION
This adds a rule that does not allow to change the order of the assigned AZs inside the `awscontrolplane` CR. This also guarantees that the former single master AZ stays in its position when more AZs are added in the update from single to HA masters.