### PR TITLE
fix order rule

### DIFF
--- a/helm/opa-mutator-app/rules/functions.rego
+++ b/helm/opa-mutator-app/rules/functions.rego
@@ -121,5 +121,5 @@ add_n_values(array_in, elem, n) = array_out {
 }
 
 orderChanged(array_old, array_new) {
-  array_old[i] == array_new[j]; i!=j
+   array_old[i] == array_new[j]; array_old[i] != array_new[i]
 }


### PR DESCRIPTION
@calvix found a bug where the "order changed" rule would be triggered when an AZ is doubled. This fixes it.